### PR TITLE
Add syntax definition for object literals

### DIFF
--- a/typescript.test/expressions.spt
+++ b/typescript.test/expressions.spt
@@ -1,7 +1,7 @@
 module expressions
 
 language typescript
-start symbol Expression
+start symbol PrimaryExpression
 
 test integer [[
 5

--- a/typescript.test/functions.spt
+++ b/typescript.test/functions.spt
@@ -26,6 +26,11 @@ function foo() {
 }
 ]] parse succeeds
 
+test function with reserved keyword [[
+function null() {
+}
+]] parse fails
+
 test function with return type [[
 function (): string {
 }

--- a/typescript.test/objects.spt
+++ b/typescript.test/objects.spt
@@ -1,0 +1,56 @@
+module functions
+
+language typescript
+start symbol PrimaryExpression
+
+test empty object [[
+{}
+]] parse succeeds
+
+test empty object whitespace [[
+{  }
+]] parse succeeds
+
+test empty object trailing comma [[
+{ , }
+]] parse fails
+
+test object with field [[
+{
+  foo: 5
+}
+]] parse succeeds
+
+test object with field trailing comma [[
+{
+  foo: 5,
+}
+]] parse succeeds
+
+test object with one identifier [[
+{
+  foo
+}
+]] parse succeeds
+
+test object with multiple fields [[
+{
+  foo,
+  foo: bar,
+  5: bar,
+  "asdf": "bar"
+}
+]] parse succeeds
+
+test object multiple fields no comma [[
+{
+  foo: bar
+  5: bar
+}
+]] parse fails
+
+test object computed field [[
+{
+  ["a"]: 5
+}
+]] parse succeeds

--- a/typescript.test/objects.spt
+++ b/typescript.test/objects.spt
@@ -1,4 +1,4 @@
-module functions
+module objects
 
 language typescript
 start symbol PrimaryExpression
@@ -21,9 +21,20 @@ test object with field [[
 }
 ]] parse succeeds
 
+test object with colon [[
+{ a:b : 1 }
+]] parse fails
+
 test object with field trailing comma [[
 {
   foo: 5,
+}
+]] parse succeeds
+
+test object with fields and trailing comma [[
+{
+  a: 1,
+  b: 2,
 }
 ]] parse succeeds
 

--- a/typescript/syntax/Common.sdf3
+++ b/typescript/syntax/Common.sdf3
@@ -4,6 +4,8 @@ lexical syntax
 
   ID             = [a-zA-Z] [a-zA-Z0-9]* 
   ID             = Keyword {reject}
+  ID             = NullLiteral {reject}
+  ID             = BooleanLiteral {reject}
   INT            = "-"? [0-9]+ 
   STRING         = "\"" StringChar* "\"" 
   StringChar     = ~[\"\n] 
@@ -58,12 +60,17 @@ lexical syntax
   Keyword = "import"
   Keyword = "try"
   
-  // NullLiteral
-  Keyword = "null"
+  Literal.null = NullLiteral
+  Literal.boolean = BooleanLiteral
+  Literal.number = NumericLiteral
+  Literal.string = STRING
   
-  // BooleanLiteral
-  Keyword = "true"
-  Keyword = "false"
+  NullLiteral.null = "null"
+  
+  BooleanLiteral.true = "true"
+  BooleanLiteral.false = "false"
+  
+  NumericLiteral.number = INT
   
   // FutureReservedWord
   Keyword = "enum"

--- a/typescript/syntax/Common.sdf3
+++ b/typescript/syntax/Common.sdf3
@@ -3,6 +3,7 @@ module Common
 lexical syntax
 
   ID             = [a-zA-Z] [a-zA-Z0-9]* 
+  ID             = Keyword {reject}
   INT            = "-"? [0-9]+ 
   STRING         = "\"" StringChar* "\"" 
   StringChar     = ~[\"\n] 
@@ -19,6 +20,55 @@ lexical syntax
   NewLineEOF     = EOF 
   EOF            =  
 
+sorts Keyword
+lexical syntax
+
+  // Keyword
+  Keyword = "break"
+  Keyword = "do"
+  Keyword = "in"
+  Keyword = "typeof"
+  Keyword = "case"
+  Keyword = "else"
+  Keyword = "instanceof"
+  Keyword = "var"
+  Keyword = "catch"
+  Keyword = "export"
+  Keyword = "new"
+  Keyword = "void"
+  Keyword = "class"
+  Keyword = "extends"
+  Keyword = "return"
+  Keyword = "while"
+  Keyword = "const"
+  Keyword = "finally"
+  Keyword = "super"
+  Keyword = "with"
+  Keyword = "continue"
+  Keyword = "for"
+  Keyword = "switch"
+  Keyword = "yield"
+  Keyword = "debugger"
+  Keyword = "function"
+  Keyword = "this"
+  Keyword = "default"
+  Keyword = "if"
+  Keyword = "throw"
+  Keyword = "delete"
+  Keyword = "import"
+  Keyword = "try"
+  
+  // NullLiteral
+  Keyword = "null"
+  
+  // BooleanLiteral
+  Keyword = "true"
+  Keyword = "false"
+  
+  // FutureReservedWord
+  Keyword = "enum"
+  Keyword = "await"
+  
 lexical restrictions
 
   // Ensure greedy matching for lexicals

--- a/typescript/syntax/typescript.sdf3
+++ b/typescript/syntax/typescript.sdf3
@@ -75,16 +75,6 @@ context-free syntax
   PrimaryExpression.literal = Literal
   PrimaryExpression.object = ObjectLiteral
   
-  Literal.null = <null>
-  Literal.boolean = BooleanLiteral
-  Literal.number = NumericLiteral
-  Literal.string = STRING
-  
-  BooleanLiteral.true = <true>
-  BooleanLiteral.false = <false>
-  
-  NumericLiteral.number = INT
-  
   ObjectLiteral.empty = <{}>
   ObjectLiteral.fields = <{<{PropertyDefinition ","}+>}>
   ObjectLiteral.fieldsTrailingComma = <{<{PropertyDefinition ","}+>,}>

--- a/typescript/syntax/typescript.sdf3
+++ b/typescript/syntax/typescript.sdf3
@@ -3,10 +3,14 @@ module typescript
 imports
   
   Common
+ 
+template options
+
+  tokenize: "(,[;{.="
 
 context-free start-symbols
   
-  Expression Statement Program
+  PrimaryExpression Statement Program
 
 context-free syntax
  
@@ -64,14 +68,39 @@ context-free syntax
   AccessibilityModifier.private = <private>
   AccessibilityModifier.protected = <protected>
   
-  Initializer.initializer = <= <Expression>>
+  Initializer.initializer = <= <PrimaryExpression>>
   
-  Expression.number = INT
-  Expression.true = <true>
-  Expression.false = <false>
-  Expression.string = STRING
-  Expression.null = <null>
-  Expression.undefined = <undefined>
+  PrimaryExpression.this = <this>
+  PrimaryExpression.identifier = BindingIdentifier
+  PrimaryExpression.literal = Literal
+  PrimaryExpression.object = ObjectLiteral
+  
+  Literal.null = <null>
+  Literal.boolean = BooleanLiteral
+  Literal.number = NumericLiteral
+  Literal.string = STRING
+  
+  BooleanLiteral.true = <true>
+  BooleanLiteral.false = <false>
+  
+  NumericLiteral.number = INT
+  
+  ObjectLiteral.empty = <{}>
+  ObjectLiteral.fields = <{<{PropertyDefinition ","}+>}>
+  ObjectLiteral.fieldsTrailingComma = <{<{PropertyDefinition ","}+>,}>
+  
+  PropertyDefinition.identifier = BindingIdentifier
+  PropertyDefinition.property = <<PropertyName>: <PrimaryExpression>>
+  
+  PropertyName.literal = LiteralPropertyName
+  PropertyName.computed = <[<PrimaryExpression>]>
+  
+  LiteralPropertyName.identifier = ID
+  LiteralPropertyName.string = STRING
+  LiteralPropertyName.number = NumericLiteral
+  
+//  PrimaryExpression.undefined = <undefined>
+//  PrimaryExpression.binary = <<PrimaryExpression> <Operator> <PrimaryExpression>>
   
   Type.void = <void>
   Type.number = <number>


### PR DESCRIPTION
Partially work for #2. Object literals are now defined in the syntax.