### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: java
+
+cache:
+ directories:
+   - $HOME/.m2
+
+jdk:
+  - oraclejdk8

--- a/typescript.example/examples/printAst.ts
+++ b/typescript.example/examples/printAst.ts
@@ -1,14 +1,14 @@
-/// <reference path="../../node_modules/@types/node/index.d.ts" />
-
-import {readFileSync} from 'fs';
-import * as ts from 'typescript';
-
-const fileNames = process.argv.slice(2);
-fileNames.forEach(fileName => {
-    // Parse a file
-    let sourceFile = ts.createSourceFile(fileName, readFileSync(fileName).toString(), ts.ScriptTarget.ES2016, /*setParentNodes */ true);
-
-    sourceFile.statements.forEach(statement => {
-      console.log(statement);
-    })
-});
+// /// <reference path="../../node_modules/@types/node/index.d.ts" />
+//
+// import {readFileSync} from 'fs';
+// import * as ts from 'typescript';
+//
+// const fileNames = process.argv.slice(2);
+// fileNames.forEach(fileName => {
+//     // Parse a file
+//     let sourceFile = ts.createSourceFile(fileName, readFileSync(fileName).toString(), ts.ScriptTarget.ES2016, /*setParentNodes */ true);
+//
+//     sourceFile.statements.forEach(statement => {
+//       console.log(statement);
+//     })
+// });

--- a/typescript.test/const-let-declarations.spt
+++ b/typescript.test/const-let-declarations.spt
@@ -1,27 +1,11 @@
 module statements
 
 language typescript
-start symbol Statement
+start symbol Declaration
 
 test const integer assignment [[
 const a = 5;
 ]] parse succeeds
-
-test var integer assignment [[
-var a = 5;
-]] parse succeeds
-
-test requires one assignemnt [[
-var ;
-]] parse fails
-
-test requires identifier [[
-var = 5;
-]] parse fails
-
-test requires expression [[
-var a =;
-]] parse fails
 
 test const declaration with type [[
 const a: number = 5;
@@ -29,10 +13,6 @@ const a: number = 5;
 
 test let declaration with type [[
 let a: number = 5;
-]] parse succeeds
-
-test var declaration with type [[
-var a: number = 5;
 ]] parse succeeds
 
 test const declaration with type uninitialized [[
@@ -43,18 +23,10 @@ test let declaration with type uninitialized [[
 let a: number;
 ]] parse succeeds
 
-test var declaration with type uninitialized [[
-var a: number;
-]] parse succeeds
-
 test const declaration without type uninitialized [[
 const a;
 ]] parse succeeds
 
 test let declaration without type uninitialized [[
 let a;
-]] parse succeeds
-
-test var declaration without type uninitialized [[
-var a;
 ]] parse succeeds

--- a/typescript.test/var-statements.spt
+++ b/typescript.test/var-statements.spt
@@ -1,0 +1,32 @@
+module statements
+
+language typescript
+start symbol Statement
+
+test var integer assignment [[
+var a = 5;
+]] parse succeeds
+
+test requires one assignemnt [[
+var ;
+]] parse fails
+
+test requires identifier [[
+var = 5;
+]] parse fails
+
+test requires expression [[
+var a =;
+]] parse fails
+
+test var declaration with type [[
+var a: number = 5;
+]] parse succeeds
+
+test var declaration with type uninitialized [[
+var a: number;
+]] parse succeeds
+
+test var declaration without type uninitialized [[
+var a;
+]] parse succeeds

--- a/typescript/pom.xml
+++ b/typescript/pom.xml
@@ -14,7 +14,52 @@
     <artifactId>parent.language</artifactId>
     <version>2.2.1</version>
   </parent>
-  
+
+  <dependencies>
+    <dependency>
+      <groupId>org.metaborg</groupId>
+      <artifactId>org.metaborg.meta.lang.esv</artifactId>
+      <type>spoofax-language</type>
+      <version>${metaborg-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.metaborg</groupId>
+      <artifactId>org.metaborg.meta.lang.nabl</artifactId>
+      <type>spoofax-language</type>
+      <version>${metaborg-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.metaborg</groupId>
+      <artifactId>org.metaborg.meta.lang.ts</artifactId>
+      <type>spoofax-language</type>
+      <version>${metaborg-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.metaborg</groupId>
+      <artifactId>org.metaborg.meta.lang.template</artifactId>
+      <type>spoofax-language</type>
+      <version>${metaborg-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.metaborg</groupId>
+      <artifactId>meta.lib.spoofax</artifactId>
+      <type>spoofax-language</type>
+      <version>${metaborg-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.metaborg</groupId>
+      <artifactId>org.metaborg.meta.lib.analysis</artifactId>
+      <type>spoofax-language</type>
+      <version>${metaborg-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.metaborg</groupId>
+      <artifactId>dynsem</artifactId>
+      <type>spoofax-language</type>
+      <version>${metaborg-version}</version>
+    </dependency>
+  </dependencies>
+
   <repositories>
     <repository>
       <id>metaborg-release-repo</id>
@@ -37,7 +82,7 @@
       </snapshots>
     </repository>
   </repositories>
-  
+
   <pluginRepositories>
     <pluginRepository>
       <id>metaborg-release-repo</id>

--- a/typescript/syntax/Objects.sdf3
+++ b/typescript/syntax/Objects.sdf3
@@ -5,11 +5,15 @@ imports
   Expressions
   Names
 
+template options
+
+  tokenize: "},{:"
+
 context-free syntax
 
   ObjectLiteral.Empty = "{" "}"
   ObjectLiteral.Fields = <{<{PropertyDefinition ","}+>}>
   ObjectLiteral.FieldsTrailingComma = "{" {PropertyDefinition ","}+ "," "}"
-  
+
   PropertyDefinition = BindingIdentifier
   PropertyDefinition.Property = <<PropertyName>: <PrimaryExpression>>

--- a/typescript/syntax/typescript.sdf3
+++ b/typescript/syntax/typescript.sdf3
@@ -10,10 +10,6 @@ imports
   Statements
   Types
  
-template options
-
-  tokenize: "(,[;{."
-
 context-free start-symbols
   
   PrimaryExpression Statement Program Declaration ObjectType


### PR DESCRIPTION
Typescript now passes on CI! It required some more dependencies in `typescript/pom.xml` and it now checks all examples and tests. So I had to fix some of these as they were broken.

It does seem that the `install` command runs all tests, even though `-DskipTests=true` is passed. This is probably an issue in Spoofax though.