### PR TITLE
Clean up AST

### DIFF
--- a/typescript/syntax/Declarations.sdf3
+++ b/typescript/syntax/Declarations.sdf3
@@ -11,21 +11,21 @@ imports
 
 context-free syntax
 
-  Declaration.interfaceDeclaration = InterfaceDeclaration
-  Declaration.hoistable = HoistableDeclaration
-  Declaration.lexical = LexicalDeclaration
+  Declaration = InterfaceDeclaration
+  Declaration = HoistableDeclaration
+  Declaration = LexicalDeclaration
   
-  HoistableDeclaration.function = <<FunctionDeclaration><SemiColon?>>
+  HoistableDeclaration.Function = <<FunctionDeclaration><SemiColon?>>
   
-  LexicalDeclaration.lexical = <<LetOrConst> <{VariableDeclaration ","}+><SemiColon?>>
+  LexicalDeclaration.Lexical = <<LetOrConst> <{VariableDeclaration ","}+><SemiColon?>>
   
-  LetOrConst.letDeclaration = <let>
-  LetOrConst.constDeclaration = <const>
+  LetOrConst.Let = <let>
+  LetOrConst.Const = <const>
   
-  VariableDeclaration.simpleVariableDeclaration = <<BindingIdentifier> <TypeAnnotation?> <Initializer?>>
+  VariableDeclaration.SimpleVariableDeclaration = <<BindingIdentifier> <TypeAnnotation?> <Initializer?>>
   
-  Initializer.initializer = <= <PrimaryExpression>>
+  Initializer.Initializer = <= <PrimaryExpression>>
   
 //  TODO
 //  InterfaceDeclaration.interface = <interface <BindingIdentifier><TypeParameters?><InterfaceExtendsClause?><ObjectType>>
-  InterfaceDeclaration.interface = <interface <BindingIdentifier><TypeParameters?><ObjectType><SemiColon?>>
+  InterfaceDeclaration.Interface = <interface <BindingIdentifier><TypeParameters?><ObjectType><SemiColon?>>

--- a/typescript/syntax/Expressions.sdf3
+++ b/typescript/syntax/Expressions.sdf3
@@ -9,12 +9,12 @@ imports
 
 context-free syntax
 
-  PrimaryExpression.this = <this>
-  PrimaryExpression.identifier = BindingIdentifier
-  PrimaryExpression.literal = Literal
-  PrimaryExpression.object = ObjectLiteral
-  PrimaryExpression.call = <<MemberExpression>(<{PrimaryExpression ","}*>)>
-  PrimaryExpression.function = FunctionDeclaration
+  PrimaryExpression.This = <this>
+  PrimaryExpression = BindingIdentifier
+  PrimaryExpression = Literal
+  PrimaryExpression = ObjectLiteral
+  PrimaryExpression.Call = <<MemberExpression>(<{PrimaryExpression ","}*>)>
+  PrimaryExpression = FunctionDeclaration
   
-  MemberExpression.primary = PrimaryExpression
-  MemberExpression.property = <<MemberExpression>.<ID>>
+  MemberExpression = PrimaryExpression
+  MemberExpression.Property = <<MemberExpression>.<ID>>

--- a/typescript/syntax/Functions.sdf3
+++ b/typescript/syntax/Functions.sdf3
@@ -8,16 +8,16 @@ imports
 
 context-free syntax
 
-  FunctionDeclaration.function = <
+  FunctionDeclaration.Function = <
   function <BindingIdentifier?><CallSignature> {
     <FunctionBody>
   }
   >
   
-  CallSignature.callSignature = <<TypeParameters?>(<ParameterList?>)<TypeAnnotation?>>
+  CallSignature.CallSignature = <<TypeParameters?>(<ParameterList?>)<TypeAnnotation?>>
   
-  ParameterList.requiredParameterList = {RequiredParameter ","}+
+  ParameterList.RequiredParameterList = {RequiredParameter ","}+
   
-  RequiredParameter.requiredParameter = /*<AccessibilityModifier?>*/<<BindingIdentifierOrPattern> <TypeAnnotation?>>
+  RequiredParameter.RequiredParameter = /*<AccessibilityModifier?>*/<<BindingIdentifierOrPattern> <TypeAnnotation?>>
   
-  FunctionBody.statementList = StatementListItem*
+  FunctionBody.Body = StatementListItem*

--- a/typescript/syntax/Names.sdf3
+++ b/typescript/syntax/Names.sdf3
@@ -7,15 +7,15 @@ imports
 
 context-free syntax
 
-  PropertyName.literal = LiteralPropertyName
-  PropertyName.computed = <[<PrimaryExpression>]>
+  PropertyName = LiteralPropertyName
+  PropertyName.Computed = <[<PrimaryExpression>]>
   
-  LiteralPropertyName.identifier = ID
-  LiteralPropertyName.string = STRING
-  LiteralPropertyName.number = NumericLiteral
+  LiteralPropertyName = ID
+  LiteralPropertyName = STRING
+  LiteralPropertyName = NumericLiteral
   
-  BindingIdentifier.identifier = ID
+  BindingIdentifier = ID
   
-  BindingIdentifierOrPattern.identifier = BindingIdentifier
+  BindingIdentifierOrPattern = BindingIdentifier
 
   

--- a/typescript/syntax/Objects.sdf3
+++ b/typescript/syntax/Objects.sdf3
@@ -7,9 +7,9 @@ imports
 
 context-free syntax
 
-  ObjectLiteral.empty = <{}>
-  ObjectLiteral.fields = <{<{PropertyDefinition ","}+>}>
-  ObjectLiteral.fieldsTrailingComma = <{<{PropertyDefinition ","}+>,}>
+  ObjectLiteral.Empty = "{" "}"
+  ObjectLiteral.Fields = <{<{PropertyDefinition ","}+>}>
+  ObjectLiteral.FieldsTrailingComma = "{" {PropertyDefinition ","}+ "," "}"
   
-  PropertyDefinition.identifier = BindingIdentifier
-  PropertyDefinition.property = <<PropertyName>: <PrimaryExpression>>
+  PropertyDefinition = BindingIdentifier
+  PropertyDefinition.Property = <<PropertyName>: <PrimaryExpression>>

--- a/typescript/syntax/Statements.sdf3
+++ b/typescript/syntax/Statements.sdf3
@@ -9,21 +9,21 @@ imports
  
 context-free priorities
 
-  ReturnStatement.value > ReturnStatement.empty
+  ReturnStatement.ValueReturn > ReturnStatement.EmptyReturn
 
 context-free syntax
 
-  Statement.variableStatement = VariableStatement
-  Statement.return = ReturnStatement
-  Statement.expression = <<ExpressionInStatement><SemiColon?>>
+  Statement = VariableStatement
+  Statement = ReturnStatement
+  Statement.Expression = <<ExpressionInStatement><SemiColon?>>
   
   ExpressionInStatement = PrimaryExpression
   ExpressionInStatement = FunctionDeclaration {reject}
   
-  VariableStatement.variable = <var <{VariableDeclaration ","}+><SemiColon?>>
+  VariableStatement.Variable = <var <{VariableDeclaration ","}+><SemiColon?>>
   
-  ReturnStatement.empty = <return;>
-  ReturnStatement.value = <return <PrimaryExpression><SemiColon?>>
+  ReturnStatement.EmptyReturn = <return;>
+  ReturnStatement.ValueReturn = <return <PrimaryExpression><SemiColon?>>
   
-  StatementListItem.statement = Statement
-  StatementListItem.declaration = Declaration
+  StatementListItem = Statement
+  StatementListItem = Declaration

--- a/typescript/syntax/Types.sdf3
+++ b/typescript/syntax/Types.sdf3
@@ -7,33 +7,33 @@ imports
 
 context-free syntax
 
-  PrimaryType.object = ObjectType
+  PrimaryType = ObjectType
   
-  ObjectType.object = <{<TypeBody?>}>
+  ObjectType.Object = <{<TypeBody?>}>
   
-  TypeBody.body = TypeMemberList
-  TypeBody.semiColon = <<TypeMemberList><SemiColon>>
-  TypeBody.comma = <<TypeMemberList><Comma>>
+  TypeBody = TypeMemberList
+  TypeBody.SemiColon = <<TypeMemberList><SemiColon>>
+  TypeBody.Comma = <<TypeMemberList><Comma>>
   
-  TypeMemberList.typemember = TypeMember
-  TypeMemberList.semiColon = <<TypeMemberList><SemiColon><TypeMember>>
-  TypeMemberList.comma = <<TypeMemberList><Comma><TypeMember>>
+  TypeMemberList = TypeMember
+  TypeMemberList.SemiColon = <<TypeMemberList><SemiColon><TypeMember>>
+  TypeMemberList.Comma = <<TypeMemberList><Comma><TypeMember>>
   
-  TypeMember.property = PropertySignature
+  TypeMember = PropertySignature
   
-  PropertySignature.property = <<LiteralPropertyName><QuestionMark?><TypeAnnotation?>>
+  PropertySignature.Property = <<LiteralPropertyName><QuestionMark?><TypeAnnotation?>>
   
-  TypeAnnotation.typeAnnotation = <: <Type>>
+  TypeAnnotation.TypeAnnotation = <: <Type>>
   
-  TypeParameters.typeParameters = <\<<{TypeParameter ","}+>\>>
+  TypeParameters.TypeParameters = <\<<{TypeParameter ","}+>\>>
  
-  TypeParameter.typeParameter = <<BindingIdentifier> <Constraint?>>
+  TypeParameter.TypeParameter = <<BindingIdentifier> <Constraint?>>
 
-  Constraint.constraint = <extends <Type>>
+  Constraint.Constraint = <extends <Type>>
 
-  Type.void = <void>
-  Type.number = <number>
-  Type.boolean = <boolean>
-  Type.string = <string>
-  Type.reference = TypeID
-  Type.object = ObjectType
+  Type.Void = <void>
+  Type.Number = <number>
+  Type.Boolean = <boolean>
+  Type.String = <string>
+  Type = TypeID
+  Type = ObjectType

--- a/typescript/syntax/typescript.sdf3
+++ b/typescript/syntax/typescript.sdf3
@@ -20,4 +20,4 @@ context-free start-symbols
 
 context-free syntax
  
-  Program.program = StatementListItem*
+  Program.Program = StatementListItem*


### PR DESCRIPTION
- Capitalize all constructors
- Remove constructors from aliases

We might need to take another look at duplicate Constructor names for different purposes. For example `Property` is used in multiple places, but all with different meanings. On this point we might have to diverge from the specification to make it work with languages like NaBl2.