### PR TITLE
Add initial try for modules

### DIFF
--- a/typescript.example/examples/modules/single-import/export.ts
+++ b/typescript.example/examples/modules/single-import/export.ts
@@ -1,0 +1,2 @@
+filename:"export"
+export const foo = 5;

--- a/typescript.example/examples/modules/single-import/export.ts
+++ b/typescript.example/examples/modules/single-import/export.ts
@@ -1,2 +1,5 @@
 filename:"export"
 export const foo = 5;
+const bar = 3;
+export const baz = bar;
+export const foo2 = foo;

--- a/typescript.example/examples/modules/single-import/import.ts
+++ b/typescript.example/examples/modules/single-import/import.ts
@@ -1,5 +1,5 @@
 filename:"import"
-import {foo} from "export";
+import {foo, baz, foo2} from "export";
 
 function bar(s: number) {}
 

--- a/typescript.example/examples/modules/single-import/import.ts
+++ b/typescript.example/examples/modules/single-import/import.ts
@@ -1,0 +1,6 @@
+filename:"import"
+import {foo} from "export";
+
+function bar(s: number) {}
+
+bar(foo);

--- a/typescript.example/examples/printAst.ts
+++ b/typescript.example/examples/printAst.ts
@@ -1,14 +1,15 @@
-filenname:"printAst"
-import {readFileSync} from "fs";
- import * as ts from 'typescript';
+filename:"printAst"
 
- const fileNames = process.argv.slice(2);
- fileNames.forEach(function(fileName) {
-     // Parse a file
-     let sourceFile = ts.createSourceFile(fileName, readFileSync(fileName).toString(), ts.ScriptTarget.ES2016, /*setParentNodes */ true);
-
-     sourceFile.statements.forEach(function(statement) {
-       console.log(statement);
-     })
- });
+//import {readFileSync} from "fs";
+//import * as ts from 'typescript';
+//
+// const fileNames = process.argv.slice(2);
+// fileNames.forEach(function(fileName) {
+//     // Parse a file
+//     let sourceFile = ts.createSourceFile(fileName, readFileSync(fileName).toString(), ts.ScriptTarget.ES2016, /*setParentNodes */ true);
+//
+//     sourceFile.statements.forEach(function(statement) {
+//       console.log(statement);
+//     })
+// });
 

--- a/typescript.example/examples/printAst.ts
+++ b/typescript.example/examples/printAst.ts
@@ -1,14 +1,14 @@
- /// <reference path="../../node_modules/@types/node/index.d.ts" />
+filenname:"printAst"
+import {readFileSync} from "fs";
+ import * as ts from 'typescript';
 
-// import {readFileSync} from 'fs';
-// import * as ts from 'typescript';
-//
-// const fileNames = process.argv.slice(2);
-// fileNames.forEach(fileName => {
-//     // Parse a file
-//     let sourceFile = ts.createSourceFile(fileName, readFileSync(fileName).toString(), ts.ScriptTarget.ES2016, /*setParentNodes */ true);
-//
-//     sourceFile.statements.forEach(statement => {
-//       console.log(statement);
-//     })
-// });
+ const fileNames = process.argv.slice(2);
+ fileNames.forEach(function(fileName) {
+     // Parse a file
+     let sourceFile = ts.createSourceFile(fileName, readFileSync(fileName).toString(), ts.ScriptTarget.ES2016, /*setParentNodes */ true);
+
+     sourceFile.statements.forEach(function(statement) {
+       console.log(statement);
+     })
+ });
+

--- a/typescript.example/examples/simple_function.ts
+++ b/typescript.example/examples/simple_function.ts
@@ -19,6 +19,7 @@ const f = foo(5);
 interface obj {
   foo: string;
   bar: number;
+  baz: {}
 }
 
 function bar(b: obj) {

--- a/typescript.example/project.unifier
+++ b/typescript.example/project.unifier
@@ -1,0 +1,35 @@
+unifier {
+  ?examples/modules/single-import/import.ts-moduleType-1 := MODULE(Module{""import"" @examples/modules/single-import/import.ts:1})
+  ?examples/modules/single-import/export.ts-valueTy-2 := NUMBER()
+  ?examples/modules/single-import/export.ts-valueTy-3 := NUMBER()
+  ?examples/modules/single-import/import.ts-tys-3 := [?examples/modules/single-import/import.ts-ty-12]
+  ?examples/modules/single-import/export.ts-moduleType-1 := MODULE(Module{""export"" @examples/modules/single-import/export.ts:1})
+  ?examples/modules/single-import/export.ts-valueTy-1 := NUMBER()
+  ?examples/modules/single-import/import.ts-tys-4 := []
+  ?examples/modules/single-import/export.ts-valueTy-4 := NUMBER()
+  ?examples/modules/single-import/export.ts-d-2 := Value{"foo" @examples/modules/single-import/export.ts:3}
+  ?examples/modules/single-import/import.ts-ty-1 := MODULE(Module{""export"" @examples/modules/single-import/export.ts:1})
+  ?examples/modules/single-import/export.ts-d-1 := Value{"bar" @examples/modules/single-import/export.ts:17}
+  ?examples/modules/single-import/import.ts-ty-3 := FUNCTION([NUMBER()],?examples/modules/single-import/import.ts-ty-7)
+  ?examples/modules/single-import/import.ts-ty-5 := NUMBER()
+  ?examples/modules/single-import/import.ts-ty-4 := [NUMBER()]
+  ?examples/modules/single-import/import.ts-returnTy-1 := ?examples/modules/single-import/import.ts-ty-7
+  ?examples/modules/single-import/import.ts-ty-6 := NUMBER()
+  ?examples/modules/single-import/import.ts-ty-9 := ?examples/modules/single-import/import.ts-ty-7
+  ?examples/modules/single-import/import.ts-ty-8 := ?examples/modules/single-import/import.ts-ty-7
+  ?examples/modules/single-import/import.ts-imported_module_scope-1 := #examples/modules/single-import/export.ts-module_scope-1
+  ?examples/modules/single-import/import.ts-paramsTy-1 := [NUMBER()]
+  ?examples/modules/single-import/import.ts-paramsTy-3 := [NUMBER()]
+  ?examples/modules/single-import/import.ts-paramsTy-2 := [NUMBER()]
+  ?examples/modules/single-import/export.ts-ty-1 := NUMBER()
+  ?examples/modules/single-import/export.ts-ty-2 := NUMBER()
+  ?examples/modules/single-import/import.ts-argsTy-1 := [?examples/modules/single-import/import.ts-ty-12]
+  ?examples/modules/single-import/import.ts-ty-11 := ?examples/modules/single-import/import.ts-ty-12
+  ?examples/modules/single-import/import.ts-m-1 := Module{""export"" @examples/modules/single-import/export.ts:1}
+  ?examples/modules/single-import/import.ts-ty-10 := FUNCTION([NUMBER()],?examples/modules/single-import/import.ts-ty-7)
+  ?examples/modules/single-import/import.ts-tys-1 := [NUMBER()]
+  ?examples/modules/single-import/import.ts-d-1 := Module{""export"" @examples/modules/single-import/export.ts:1}
+  ?examples/modules/single-import/import.ts-tys-2 := []
+  ?examples/modules/single-import/import.ts-functionTy-1 := FUNCTION([NUMBER()],?examples/modules/single-import/import.ts-ty-7)
+  ?examples/modules/single-import/import.ts-d-3 := Value{"bar" @examples/modules/single-import/import.ts:14}
+}

--- a/typescript/editor/Analysis.esv
+++ b/typescript/editor/Analysis.esv
@@ -7,4 +7,4 @@ imports
 
 language
 
-  observer : editor-analyze (constraint)
+  observer : editor-analyze (constraint) (multifile)

--- a/typescript/syntax/Common.sdf3
+++ b/typescript/syntax/Common.sdf3
@@ -11,9 +11,13 @@ lexical syntax
   TypeID         = BooleanLiteral {reject}
   INT            = "-"? [0-9]+ 
   STRING         = "\"" StringChar* "\"" 
+  STRING         = "'" StringCharSingle* "'"
   StringChar     = ~[\"\n] 
   StringChar     = "\\\"" 
-  StringChar     = BackSlashChar 
+  StringChar     = BackSlashChar
+  StringCharSingle = ~[\'\n]
+  StringCharSingle = "\\'" 
+  StringCharSingle = BackSlashChar
   BackSlashChar  = "\\" 
   LAYOUT         = [\ \t\n\r] 
   CommentChar    = [\*] 

--- a/typescript/syntax/Modules.sdf3
+++ b/typescript/syntax/Modules.sdf3
@@ -26,7 +26,7 @@ context-free syntax
   
   ModuleItem = ImportDeclaration
   ModuleItem = ExportDeclaration
-  ModuleItem = StatementListItem
+  ModuleItem.ModuleStatement = StatementListItem
   
   ImportDeclaration.ImportClause = <import <ImportClause> <FromClause> <SemiColon?>>
   

--- a/typescript/syntax/Modules.sdf3
+++ b/typescript/syntax/Modules.sdf3
@@ -1,0 +1,53 @@
+module Modules
+
+imports
+
+  Common
+  Declarations
+  Names
+  Statements
+
+template options
+
+  tokenize: "},{"
+
+context-free syntax
+
+  Module.Module = <
+    filename:<STRING>
+    <ModuleBody?>
+  >
+  
+  // Without these productions, a full statement list is ambiguous in that it can
+  // also be a Module. Thus we have to force that at least one export or import
+  // is inside a module, to thus distinguish between modules and normal programs
+  ModuleBody.ModuleItemsWithExport = StatementListItem* ExportDeclaration ModuleItem*
+  ModuleBody.ModuleItemsWithImport = StatementListItem* ImportDeclaration ModuleItem*
+  
+  ModuleItem = ImportDeclaration
+  ModuleItem = ExportDeclaration
+  ModuleItem = StatementListItem
+  
+  ImportDeclaration.ImportClause = <import <ImportClause> <FromClause> <SemiColon?>>
+  
+  ImportClause = NamespaceImport
+  ImportClause = NamedImports
+  
+  NamespaceImport.NameSpaceImport = <* as <ImportedBinding>>
+  
+  ImportedBinding = BindingIdentifier
+  
+  NamedImports.ImportsEmpty = <{}>
+  NamedImports.ImportsList = <{<{ImportSpecifier ","}+><Comma?>}>
+  
+  FromClause.From = <from <ModuleSpecifier>>
+  
+  ModuleSpecifier = STRING
+  
+  ImportSpecifier.NamedImport = ImportedBinding
+  ImportSpecifier.AsImport = <<BindingIdentifier> as <ImportedBinding>>
+  
+  ExportDeclaration.ExportStar = <export * <FromClause>>
+  ExportDeclaration.ExportDeclaration = <export <Declaration>>
+  
+  

--- a/typescript/syntax/typescript.sdf3
+++ b/typescript/syntax/typescript.sdf3
@@ -5,6 +5,7 @@ imports
   Common
   Declarations
   Expressions
+  Modules
   Names
   Objects
   Statements
@@ -16,4 +17,5 @@ context-free start-symbols
 
 context-free syntax
  
+  Program.Module  = Module
   Program.Program = StatementListItem*

--- a/typescript/trans/desugaring/desugar.str
+++ b/typescript/trans/desugaring/desugar.str
@@ -44,6 +44,12 @@ rules
   desugar: CallSignature(typeParameters, Some(parameters), None()) -> CallSignature(typeParameters, Parameters(parameters), NoReturnType())
   desugar: CallSignature(typeParameters, None(), Some(returnType)) -> CallSignature(typeParameters, NoParameters(), ReturnType(returnType))
   desugar: CallSignature(typeParameters, Some(parameters), Some(returnType)) -> CallSignature(typeParameters, Parameters(parameters), ReturnType(returnType))
+  
+  desugar: Module(Module(name, Some(body))) -> Module(name, body)
+  desugar: Module(Module(name, None())) -> Module(name, [])
+  
+  desugar: ModuleItemsWithExport(items, item, items3) -> <concat> [items, [item], items3]
+  desugar: ModuleItemsWithImport(items, item, items3) -> <concat> [items, [item], items3]
 	
 strategies
   	desugar-all = bottomup(try(desugar))

--- a/typescript/trans/typechecking/typescript.nabl2
+++ b/typescript/trans/typechecking/typescript.nabl2
@@ -10,6 +10,7 @@ signature
     
     constructors
     	RECORD	: scope -> Type
+    	MODULE  : scope -> Type
     	
     	NUMBER	  : Type
 		  STRING	  : Type
@@ -21,7 +22,7 @@ signature
 	name resolution
 		labels
 	      P I
-	
+	      
 	    order
 	      D < I,
 	      D < P,
@@ -42,10 +43,39 @@ rules
     	new s.
     
     [[ Program(statements) ^ (s) ]] :=
-    	Map1 [[ statements ^ (s) ]],
-    	distinct/name D(s)/Value | error @ NAMES,
-    	distinct/name D(s)/Type | error @ NAMES.
-    	
+      new program_scope,
+      program_scope -P-> s,
+    	Map1 [[ statements ^ (program_scope) ]],
+    	distinct/name D(program_scope)/Value | error @ NAMES,
+    	distinct/name D(program_scope)/Type | error @ NAMES.
+    
+    [[ Module(name, body) ^ (s) ]] :=
+      new module_scope,
+      module_scope -P-> s,
+      Module{name} <- s,
+      Map1 [[ body ^ (module_scope) ]],
+      distinct/name D(module_scope)/Value | error @ NAMES,
+      distinct/name D(module_scope)/Type | error @ NAMES.
+      
+    [[ ExportDeclaration(declaration) ^ (s) ]] :=
+      new export_scope,
+      s -E-> export_scope,
+      [[ declaration ^ (export_scope) ]].
+    
+    [[ ImportClause(imports, From(filename), _) ^ (s) ]] :=
+      Module{filename} ?===> module_scope,
+      new import_scope,
+      [[ imports ^ (import_scope, module_scope) ]].
+    
+    [[ ImportsList(list, _) ^ (import_scope, module_scope) ]] :=
+      Map2 [[ list ^ (import_scope, module_scope) ]].
+    
+    [[ NamedImport(name) ^ (import_scope, module_scope) ]] :=
+      Value{name} -> module_scope,
+      Value{name} |-> d,
+      d: ty,
+      Value{name} <- import_scope,
+      Value{name} : ty !.
     	
     [[ InterfaceDecl(name, _, fields) ^ (s) ]] :=
     	Type{name} <- s,

--- a/typescript/trans/typechecking/typescript.nabl2
+++ b/typescript/trans/typechecking/typescript.nabl2
@@ -6,6 +6,10 @@ imports
   typechecking/-
   
 signature
+
+	constraint generator
+		Map3	[[ list(a) ^ (b,c,d) ]]
+		Map3(X)	[[ list(a) ^ (b,c,d) ]]
     
     
     constructors
@@ -17,6 +21,7 @@ signature
 		  BOOLEAN   : Type
 		  UNDEFINED : Type
 		  FUNCTION  : list(Type) * Type -> Type
+		  MODULE	: occurrence -> Type
 		
 
 	name resolution
@@ -38,6 +43,12 @@ signature
 			Return
       
 rules
+
+	Map3	[[ xs ^ (b,c,d) ]] := Map3(default) [[ xs ^ (b,c,d) ]].
+	Map3(X)	[[ [x|xs] ^ (s1,s2,s3) ]] :=
+	    X[[ x ^ (s1,s2,s3) ]],
+	    Map3(X)[[ xs ^ (s1,s2,s3) ]].
+	Map3(X)[[ [] ^ (s1,s2,s3) ]].
 	
 	init ^ (s) :=
     	new s.
@@ -51,30 +62,44 @@ rules
     
     [[ Module(name, body) ^ (s) ]] :=
       new module_scope,
-      module_scope -P-> s,
-      Module{name} <- s,
-      Map1 [[ body ^ (module_scope) ]],
-      distinct/name D(module_scope)/Value | error @ NAMES,
-      distinct/name D(module_scope)/Type | error @ NAMES.
-      
-    [[ ExportDeclaration(declaration) ^ (s) ]] :=
+      new statement_scope,
       new export_scope,
-      s -E-> export_scope,
+      module_scope -I-> export_scope,
+      module_scope -P-> s,
+      statement_scope -P-> module_scope,
+      export_scope -P-> statement_scope,
+      Module{name} <- s,
+      Module{name} ===> module_scope,
+      Module{name} : moduleType,
+      moduleType == MODULE(Module{name}),
+      Map3 [[ body ^ (module_scope, export_scope, statement_scope) ]],
+      distinct/name (D(statement_scope)/Value union D(export_scope)/Value) | error @ NAMES,
+      distinct/name (D(statement_scope)/Type union D(export_scope)/Type) | error @ NAMES.
+      
+    [[ ExportDeclaration(declaration) ^ (module_scope, export_scope, statement_scope) ]] :=
       [[ declaration ^ (export_scope) ]].
     
-    [[ ImportClause(imports, From(filename), _) ^ (s) ]] :=
-      Module{filename} ?===> module_scope,
+    [[ ModuleStatement(statement) ^ (module_scope, export_scope, statement_scope) ]] :=
+      [[ statement ^ (statement_scope) ]].
+    
+    [[ ImportClause(imports, From(filename), _) ^ (module_scope, export_scope, statement_scope) ]] :=
+      Module{filename} -> module_scope,
+      Module{filename} |-> d | error $[Could not find module [filename]],
+      d : ty,
+      ty == MODULE(m),
+      m ?===> imported_module_scope,
       new import_scope,
-      [[ imports ^ (import_scope, module_scope) ]].
+      import_scope -P-> imported_module_scope,
+      [[ imports ^ (import_scope, statement_scope) ]].
     
-    [[ ImportsList(list, _) ^ (import_scope, module_scope) ]] :=
-      Map2 [[ list ^ (import_scope, module_scope) ]].
+    [[ ImportsList(list, _) ^ (import_scope, statement_scope) ]] :=
+      Map2 [[ list ^ (import_scope, statement_scope) ]].
     
-    [[ NamedImport(name) ^ (import_scope, module_scope) ]] :=
-      Value{name} -> module_scope,
-      Value{name} |-> d,
+    [[ NamedImport(name) ^ (import_scope, statement_scope) ]] :=
+      Value{name} -> import_scope,
+      Value{name} |-> d | error $[Could not find exported value [name].],
       d: ty,
-      Value{name} <- import_scope,
+      Value{name} <- statement_scope,
       Value{name} : ty !.
     	
     [[ InterfaceDecl(name, _, fields) ^ (s) ]] :=


### PR DESCRIPTION
This is work in progress, as it is completely broken atm :sob: 

To be able to support modules, we need to export a subset of the values defined in the module scope. Then when importing, we explicitly have to go through these values and retrieve the types.

The syntax definition is a good start and working, but the nabl2 typechecker is not working at all. I tried to venture through my compiler construction solution to find how we should solve it, but unsuccessful thus far. We probably need to pair program this part next week when you are back.